### PR TITLE
unifying secrets holding schema registry value

### DIFF
--- a/src/main/kubernetes/deployment.yaml
+++ b/src/main/kubernetes/deployment.yaml
@@ -92,6 +92,8 @@ spec:
             name: vaccine-order-ms-cm
         - configMapRef:
             name: kafka-topics-cm
+        - secretRef:
+            name: kafka-schema-registry
         image: quay.io/ibmcase/vaccineorderms
         imagePullPolicy: Always
         livenessProbe:

--- a/src/main/kubernetes/kafka-schema-registry-secret.yaml
+++ b/src/main/kubernetes/kafka-schema-registry-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vaccine-order-ms
+  name: kafka-schema-registry
 stringData:
   SCHEMA_REGISTRY_URL: https://<SCRAM_USERNAME>:<SCRAM_PASSWORD>@<SCHEMA_REGISTRY_URL>

--- a/src/main/kubernetes/kafka-topics-configmap.yaml
+++ b/src/main/kubernetes/kafka-topics-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kafka-topics-cm
 data:
   KAFKA_BOOTSTRAP_SERVERS: <KAFKA_BOOTSTRAP_URL>
+  KAFKA_BOOTSTRAP_SERVERS_EXT: <EXTERNAL_KAFKA_BOOTSTRAP_URL>
   ORDER_TOPIC: "<UNIQUE_ID>.vaccine.public.orderevents"
   REEFER_TELEMETRY_TOPIC: "<UNIQUE_ID>.vaccine.reefer.telemetry"
   SHIPMENT_PLAN_TOPIC: "<UNIQUE_ID>.vaccine.shipment.plan"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,7 +62,7 @@ quarkus.index-dependency.outbox.group-id=io.debezium
 quarkus.index-dependency.outbox.artifact-id=debezium-quarkus-outbox
 quarkus.debezium-outbox.table-name=orderevents
 # change to true in prod
-quarkus.debezium-outbox.remove-after-insert=true
+quarkus.debezium-outbox.remove-after-insert=false
 
 #################################
 # Kafka config


### PR DESCRIPTION
Unified the schema registry url under the kafka-schema-registry-secret.yaml in this repo to be reused by any other component in the vaccine order manager use case. As a result, I needed to adjust the deployment for this component as well as the VORO component to load this secret too.